### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
 
   def index
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
 
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new
@@ -18,8 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
-private
+  private
+
   def item_params
-    params.require(:item).permit(:image, :name, :explan, :category_id, :status_id, :shippingfee_payer_id, :prefecture_id, :shipping_day_id, :price).merge(user_id:current_user.id)
+    params.require(:item).permit(:image, :name, :explan, :category_id, :status_id, :shippingfee_payer_id, :prefecture_id,
+                                 :shipping_day_id, :price).merge(user_id: current_user.id)
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -13,6 +13,6 @@ class Category < ActiveHash::Base
     { id: 11, name: 'その他' }
   ]
 
-    include ActiveHash::Associations
-    has_many :items
-  end
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,9 +1,11 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   validates :image, :name, :explan, presence: true
-  validates :category_id, :status_id, :shippingfee_payer_id, :prefecture_id, :shipping_day_id, numericality: { other_than: 1, message: "can't be blank"}
-  validates :price,  presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 300,less_than_or_equal_to: 9999999}, format: /\A[0-9]+\z/
-  
+  validates :category_id, :status_id, :shippingfee_payer_id, :prefecture_id, :shipping_day_id,
+            numericality: { other_than: 1, message: "can't be blank" }
+  validates :price, presence: true,
+                    numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }, format: /\A[0-9]+\z/
+
   belongs_to :user
   belongs_to :category
   belongs_to :status

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,24 +1,24 @@
 class Prefecture < ActiveHash::Base
   self.data = [
-    {id: 1, name: '--' },
-    {id: 2, name: '北海道'}, {id: 3, name: '青森県'}, {id: 4, name: '岩手県'},
-    {id: 5, name: '宮城県'}, {id: 6, name: '秋田県'}, {id: 7, name: '山形県'},
-    {id: 8, name: '福島県'}, {id: 9, name: '茨城県'}, {id: 10, name: '栃木県'},
-    {id: 11, name: '群馬県'}, {id: 12, name: '埼玉県'}, {id: 13, name: '千葉県'},
-    {id: 14, name: '東京都'}, {id: 15, name: '神奈川県'}, {id: 16, name: '新潟県'},
-    {id: 17, name: '富山県'}, {id: 18, name: '石川県'}, {id: 19, name: '福井県'},
-    {id: 20, name: '山梨県'}, {id: 21, name: '長野県'}, {id: 22, name: '岐阜県'},
-    {id: 23, name: '静岡県'}, {id: 24, name: '愛知県'}, {id: 25, name: '三重県'},
-    {id: 26, name: '滋賀県'}, {id: 27, name: '京都府'}, {id: 28, name: '大阪府'},
-    {id: 29, name: '兵庫県'}, {id: 30, name: '奈良県'}, {id: 31, name: '和歌山県'},
-    {id: 32, name: '鳥取県'}, {id: 33, name: '島根県'}, {id: 34, name: '岡山県'},
-    {id: 35, name: '広島県'}, {id: 36, name: '山口県'}, {id: 37, name: '徳島県'},
-    {id: 38, name: '香川県'}, {id: 39, name: '愛媛県'}, {id: 40, name: '高知県'},
-    {id: 41, name: '福岡県'}, {id: 42, name: '佐賀県'}, {id: 43, name: '長崎県'},
-    {id: 44, name: '熊本県'}, {id: 45, name: '大分県'}, {id: 46, name: '宮崎県'},
-    {id: 47, name: '鹿児島県'}, {id: 48, name: '沖縄県'}
+    { id: 1, name: '--' },
+    { id: 2, name: '北海道' }, { id: 3, name: '青森県' }, { id: 4, name: '岩手県' },
+    { id: 5, name: '宮城県' }, { id: 6, name: '秋田県' }, { id: 7, name: '山形県' },
+    { id: 8, name: '福島県' }, { id: 9, name: '茨城県' }, { id: 10, name: '栃木県' },
+    { id: 11, name: '群馬県' }, { id: 12, name: '埼玉県' }, { id: 13, name: '千葉県' },
+    { id: 14, name: '東京都' }, { id: 15, name: '神奈川県' }, { id: 16, name: '新潟県' },
+    { id: 17, name: '富山県' }, { id: 18, name: '石川県' }, { id: 19, name: '福井県' },
+    { id: 20, name: '山梨県' }, { id: 21, name: '長野県' }, { id: 22, name: '岐阜県' },
+    { id: 23, name: '静岡県' }, { id: 24, name: '愛知県' }, { id: 25, name: '三重県' },
+    { id: 26, name: '滋賀県' }, { id: 27, name: '京都府' }, { id: 28, name: '大阪府' },
+    { id: 29, name: '兵庫県' }, { id: 30, name: '奈良県' }, { id: 31, name: '和歌山県' },
+    { id: 32, name: '鳥取県' }, { id: 33, name: '島根県' }, { id: 34, name: '岡山県' },
+    { id: 35, name: '広島県' }, { id: 36, name: '山口県' }, { id: 37, name: '徳島県' },
+    { id: 38, name: '香川県' }, { id: 39, name: '愛媛県' }, { id: 40, name: '高知県' },
+    { id: 41, name: '福岡県' }, { id: 42, name: '佐賀県' }, { id: 43, name: '長崎県' },
+    { id: 44, name: '熊本県' }, { id: 45, name: '大分県' }, { id: 46, name: '宮崎県' },
+    { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
   ]
 
-    include ActiveHash::Associations
-    has_many :items
-  end
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/shipping_day.rb
+++ b/app/models/shipping_day.rb
@@ -3,9 +3,9 @@ class ShippingDay < ActiveHash::Base
     { id: 1, name: '--' },
     { id: 2, name: '1~2日で発送' },
     { id: 3, name: '2~3日で発送' },
-    { id: 4, name: '4~7日で発送' },
+    { id: 4, name: '4~7日で発送' }
   ]
 
-    include ActiveHash::Associations
-    has_many :items
-  end
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/shippingfee_payer.rb
+++ b/app/models/shippingfee_payer.rb
@@ -5,6 +5,6 @@ class ShippingfeePayer < ActiveHash::Base
     { id: 3, name: '送料込み(出品者負担)' }
   ]
 
-    include ActiveHash::Associations
-    has_many :items
-  end
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -9,6 +9,6 @@ class Status < ActiveHash::Base
     { id: 7, name: '全体的に状態が悪い' }
   ]
 
-    include ActiveHash::Associations
-    has_many :items
-  end
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,8 +7,10 @@ class User < ApplicationRecord
   validates :nickname, presence: true
   validates :password,
             format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: 'is invalid. Include both letters and numbers' }
-  validates :lastname_full,  presence: true, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'is invalid. Input full-width characters' }
-  validates :firstname_full, presence: true, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'is invalid. Input full-width characters' }
+  validates :lastname_full,  presence: true,
+                             format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'is invalid. Input full-width characters' }
+  validates :firstname_full, presence: true,
+                             format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'is invalid. Input full-width characters' }
   validates :lastname_kana,  presence: true,
                              format: { with: /\A[ァ-ヶー－]+\z/, message: 'is invalid. Input full-width katakana characters' }
   validates :firstname_kana, presence: true,

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,11 +128,12 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% if Item.exists? %>
+      <% @items.each do |item|%>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag(item.image, class: "item-img") %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -143,10 +144,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shippingfee_payer.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -154,11 +155,9 @@
           </div>
         </div>
         <% end %>
+        <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,8 +175,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :item do
-    name                  {Faker::Commerce.product_name}
-    explan                {Faker::Lorem.sentence}
-    category_id           {Faker::Number.between(from: 2, to: 11)}
-    status_id             {Faker::Number.between(from: 2, to: 7)}
-    shippingfee_payer_id  {Faker::Number.between(from: 2, to: 3)}
-    prefecture_id         {Faker::Number.between(from: 2, to: 48)}
-    shipping_day_id       {Faker::Number.between(from: 2, to: 4)}
-    price                 {Faker::Number.between(from: 300, to: 9999999)}
+    name                  { Faker::Commerce.product_name }
+    explan                { Faker::Lorem.sentence }
+    category_id           { Faker::Number.between(from: 2, to: 11) }
+    status_id             { Faker::Number.between(from: 2, to: 7) }
+    shippingfee_payer_id  { Faker::Number.between(from: 2, to: 3) }
+    prefecture_id         { Faker::Number.between(from: 2, to: 48) }
+    shipping_day_id       { Faker::Number.between(from: 2, to: 4) }
+    price                 { Faker::Number.between(from: 300, to: 9_999_999) }
 
     association :user
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe Item, type: :model do
 
   describe '商品出品' do
     context '商品が出品できる場合' do
-      it 'image,name,explan,category_id,status_id,shippingfee_payer_id,prefecture_id,shipping_day_id,priceが存在していれば出品できる'do
+      it 'image,name,explan,category_id,status_id,shippingfee_payer_id,prefecture_id,shipping_day_id,priceが存在していれば出品できる' do
         expect(@item).to be_valid
       end
     end
     context '商品が出品できない場合' do
       it 'imageが空では出品できない' do
         @item.image = nil
-        @item.valid?        
+        @item.valid?
         expect(@item.errors.full_messages).to include("Image can't be blank")
       end
       it 'nameが空では出品できない' do
@@ -60,22 +60,22 @@ RSpec.describe Item, type: :model do
       it 'Userが紐付いていないと出品できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("User must exist")
+        expect(@item.errors.full_messages).to include('User must exist')
       end
       it 'priceに半角数字以外が含まれている場合は出品できない' do
         @item.price = '10000あ'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it 'priceが300円未満では出品できない' do
         @item.price = '299'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be greater than or equal to 300")
+        expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
       end
       it ' priceが9999999円を超えると出品できない' do
         @item.price = '10000000'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be less than or equal to 9999999")
+        expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
       end
       it 'category_idが未選択(id = 1)では出品できない' do
         @item.category_id = 1

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,7 +30,7 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
-I18n.locale = "en"
+I18n.locale = 'en'
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
# what
商品一覧表示機能の実装
商品データの有無による条件分岐

# why
商品を出品した際に、トップページに降順で商品データが掲載されるようにするため
また商品のデータがない場合は、ダミー商品を表示させるため

①商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/f3dd8b39489f99c63e9ac33cbee610d0
②商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）
https://gyazo.com/d903549d15c3817ff773891195480ce9